### PR TITLE
Fixed Game Object Accumulation in Deck Select

### DIFF
--- a/Assets/Scripts/DeckCreation/DeckSelectionManager.cs
+++ b/Assets/Scripts/DeckCreation/DeckSelectionManager.cs
@@ -281,6 +281,7 @@ public class DeckSelectionManager : MonoBehaviour
         characterSelectionUi.SetActive(false);
         weaponSelectionUi.SetActive(true);
         deckSelectionUi.SetActive(false);
+        UnrenderDecks();
         weaponText.TextUpdate(playerData.selectedWeapons.Count.ToString() + "/2 Selected");
         foreach (Transform child in weaponSelectionUi.transform)
         {
@@ -333,8 +334,6 @@ public class DeckSelectionManager : MonoBehaviour
     //Renders the weaponDeck corresponding to (@param weaponType)
     public void RenderDecks(WeaponEditInformation weaponEditInformation)
     {
-        UnrenderDecks();
-
         WeaponType weaponType = weaponEditInformation.WeaponType;
         List<ActionClass> chosenCardList = cardDatabase.ConvertStringsToCards(weaponType, playerData.GetDeckByWeaponType(weaponType).Select(p => p.ActionClassName).ToList());
         List<ActionClass> cardsToRender = weaponEditInformation.GetCards(cardDatabase);
@@ -354,7 +353,7 @@ public class DeckSelectionManager : MonoBehaviour
         //In order to sort, the cards must be instantiated and initialized first :pensive:
         foreach (ActionClass card in cardsToRender)
         {
-            GameObject go = Instantiate(card.gameObject, new Vector3(-100, -100, 1), Quaternion.identity);
+            GameObject go = Instantiate(card.gameObject, new Vector3(-100, -100, 1), Quaternion.identity, cardArrayParent.transform);
             instantiatedCards.Add(go);
             ActionClass ac = go.GetComponent<ActionClass>();
             ActionClass? pref = chosenCardList.FirstOrDefault(action => action.GetType() == card.GetType());


### PR DESCRIPTION
Fixed object accumulation by instantiating them in the correct parent, also changed deck unrender behavior to unrender on back button press while previously it unrendered only on the next deck select.

Testing:
- To make sure unrendering behaves properly: Select a character, select a weapon, edit the deck, and go back. You should now see the card game objects be deleted.
- Play a scene with modified decks to make sure other functionality isnt affected