### PR TITLE
Credit Scroll Speedup

### DIFF
--- a/Assets/Scripts/LevelSelect/CreditsManager.cs
+++ b/Assets/Scripts/LevelSelect/CreditsManager.cs
@@ -7,6 +7,9 @@ public class CreditsManager : MonoBehaviour
     public Animator animator;
     public Image blackBg;
     public UIFadeHandler fadeHandler;
+    public bool fastForward;
+    public float speedNormal = 1f;
+    public float speedFast = 10f;
 
     void Start()
     {
@@ -40,5 +43,10 @@ public class CreditsManager : MonoBehaviour
         }
 
         blackBg.color = endColor;
+    }
+
+    void Update() {
+        fastForward = Input.GetKey(KeyCode.Space) || Input.GetKey(KeyCode.RightArrow);
+        animator.speed = fastForward ? speedFast : speedNormal;
     }
 }

--- a/Assets/Scripts/LevelSelect/CreditsManager.cs
+++ b/Assets/Scripts/LevelSelect/CreditsManager.cs
@@ -7,7 +7,6 @@ public class CreditsManager : MonoBehaviour
     public Animator animator;
     public Image blackBg;
     public UIFadeHandler fadeHandler;
-    public bool fastForward;
     public float speedNormal = 1f;
     public float speedFast = 10f;
 
@@ -46,7 +45,7 @@ public class CreditsManager : MonoBehaviour
     }
 
     void Update() {
-        fastForward = Input.GetKey(KeyCode.Space) || Input.GetKey(KeyCode.RightArrow);
+        bool fastForward = Input.GetKey(KeyCode.Space) || Input.GetKey(KeyCode.RightArrow) || Input.GetKey(KeyCode.Mouse0);
         animator.speed = fastForward ? speedFast : speedNormal;
     }
 }


### PR DESCRIPTION
Added functionality to increase the scrolling animation's speed while right arrow or space is held. There seems to be a limit to how much the animation can be sped up so if we need it even faster then we may need to consider other methods