### PR TITLE
Crosshair crystals too

### DIFF
--- a/Assets/Scripts/Managers/CombatManager.cs
+++ b/Assets/Scripts/Managers/CombatManager.cs
@@ -339,7 +339,7 @@ public class CombatManager : MonoBehaviour
 
     private void CrosshairAllEnemies()
     {
-        foreach (var enemy in enemyTeam)
+        foreach (var enemy in enemyTeam.Concat(neutralTeam))
         {
             enemy.CrossHair();
         }
@@ -347,7 +347,7 @@ public class CombatManager : MonoBehaviour
 
     private void UncrosshairAllEnemies()
     {
-        foreach (var enemy in enemyTeam)
+        foreach (var enemy in enemyTeam.Concat(neutralTeam))
         {
             enemy.UnCrossHair();
         }


### PR DESCRIPTION
Resolves #147.

Made `CrosshairAllEnemies` and `UncrosshairAllEnemies` include `neutralTeam` also. 