### PR TITLE
Andrew/fix topleft icons sticky tooltip

### DIFF
--- a/Assets/Scripts/UI Toolkit/PauseMenuV2.cs
+++ b/Assets/Scripts/UI Toolkit/PauseMenuV2.cs
@@ -107,16 +107,24 @@ namespace UI_Toolkit
 
         private void HandleUIContextChanged(UIContextChangedEvent e) {
             var flags = e.context switch {
-                UIContext.Combat   => UIContextCustomFlags.DialogueLog | UIContextCustomFlags.AutoRoll | UIContextCustomFlags.DoubleSpeed,
-                UIContext.Dialogue => UIContextCustomFlags.DialogueLog | UIContextCustomFlags.SkipDialogue,
-                UIContext.Custom data  => data.Flags,
-                _                  => UIContextCustomFlags.None,
+                UIContext.Combat        => UIContextCustomFlags.DialogueLog | UIContextCustomFlags.AutoRoll | UIContextCustomFlags.DoubleSpeed,
+                UIContext.Dialogue      => UIContextCustomFlags.DialogueLog | UIContextCustomFlags.SkipDialogue,
+                UIContext.Custom data   => data.Flags,
+                _                       => UIContextCustomFlags.None,
             };
 
-            autoRollToggle.Display(flags.HasFlag(UIContextCustomFlags.AutoRoll));
-            doubleSpeedToggle.Display(flags.HasFlag(UIContextCustomFlags.DoubleSpeed));
-            dialogueLogButton.Display(flags.HasFlag(UIContextCustomFlags.DialogueLog));
-            skipDialogueButton.Display(flags.HasFlag(UIContextCustomFlags.SkipDialogue));
+            SetButtonVisibility(autoRollToggle,      flags.HasFlag(UIContextCustomFlags.AutoRoll));
+            SetButtonVisibility(doubleSpeedToggle,   flags.HasFlag(UIContextCustomFlags.DoubleSpeed));
+            SetButtonVisibility(dialogueLogButton,   flags.HasFlag(UIContextCustomFlags.DialogueLog));
+            SetButtonVisibility(skipDialogueButton,  flags.HasFlag(UIContextCustomFlags.SkipDialogue));
+        }
+
+        private void SetButtonVisibility(VisualElement element, bool visible) {
+            if (!visible && element.style.display != DisplayStyle.None)
+                HideTooltip();
+            element.Display(visible);
+            if (!visible)
+                IsOverBlockingElement = false;
         }
         
         private void RegisterBlockingElement(VisualElement element)

--- a/Assets/Scripts/UI Toolkit/PauseMenuV2.cs
+++ b/Assets/Scripts/UI Toolkit/PauseMenuV2.cs
@@ -88,6 +88,7 @@ namespace UI_Toolkit
         private void DoStart()
         {
             SetState(State.Unpaused);
+            HideTooltip();
             new PauseStateChangedEvent(false).Invoke();
             SaveLoadSystem.Instance.SavePreferences();
         }


### PR DESCRIPTION
hides tooltip when:

1. the button disappears due to context changes
2. the scene is reloaded

prevents a known sticky tooltip bug in queenbeetlefight